### PR TITLE
chore(deps): bump fsspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ REQUIRED_PKGS = [
     "multiprocess",
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0",
+    "fsspec[http]>=2023.1.0,<=2024.3.1",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co


### PR DESCRIPTION
There were a few fixes released recently, some DVC ecosystem packages require newer version of fsspec